### PR TITLE
feat: Add members to DE and OU groups response

### DIFF
--- a/src/main/java/org/hisp/dhis/Dhis2.java
+++ b/src/main/java/org/hisp/dhis/Dhis2.java
@@ -86,7 +86,6 @@ public class Dhis2
     /**
      * Creates a {@link Dhis2} instance configured for basic authentication.
      *
-     *
      * @param url the URL to the DHIS 2 instance, do not include the
      *        {@code /api} part or a trailing {@code /}.
      * @param username the DHIS 2 account username.
@@ -541,10 +540,13 @@ public class Dhis2
      */
     public OrgUnitGroup getOrgUnitGroup( String id )
     {
+        String fieldsParams = String.format(
+            "%1$s,organisationUnits[%2$s]", NAME_FIELDS, ORG_UNIT_FIELDS );
+
         return getObject( config.getResolvedUriBuilder()
             .appendPath( "organisationUnitGroups" )
             .appendPath( id )
-            .addParameter( "fields", NAME_FIELDS ), Query.instance(), OrgUnitGroup.class );
+            .addParameter( "fields", fieldsParams ), Query.instance(), OrgUnitGroup.class );
     }
 
     /**
@@ -555,9 +557,13 @@ public class Dhis2
      */
     public List<OrgUnitGroup> getOrgUnitGroups( Query query )
     {
+        String fieldsParams = query.isExpandAssociations() ? String.format(
+            "%1$s,organisationUnits[%2$s]", NAME_FIELDS, ORG_UNIT_FIELDS )
+            : NAME_FIELDS;
+
         return getObject( config.getResolvedUriBuilder()
             .appendPath( "organisationUnitGroups" )
-            .addParameter( "fields", NAME_FIELDS ), query, Objects.class )
+            .addParameter( "fields", fieldsParams ), query, Objects.class )
                 .getOrganisationUnitGroups();
     }
 
@@ -1048,10 +1054,13 @@ public class Dhis2
      */
     public DataElementGroup getDataElementGroup( String id )
     {
+        String fieldsParams = String.format(
+            "%1$s,dataElements[%2$s]", NAME_FIELDS, DATA_ELEMENT_FIELDS );
+
         return getObject( config.getResolvedUriBuilder()
             .appendPath( "dataElementGroups" )
             .appendPath( id )
-            .addParameter( "fields", NAME_FIELDS ), Query.instance(), DataElementGroup.class );
+            .addParameter( "fields", fieldsParams ), Query.instance(), DataElementGroup.class );
     }
 
     /**
@@ -1062,9 +1071,12 @@ public class Dhis2
      */
     public List<DataElementGroup> getDataElementGroups( Query query )
     {
+        String fieldsParams = query.isExpandAssociations() ? String.format(
+            "%1$s,dataElements[%2$s]", NAME_FIELDS, DATA_ELEMENT_FIELDS )
+            : NAME_FIELDS;
         return getObject( config.getResolvedUriBuilder()
             .appendPath( "dataElementGroups" )
-            .addParameter( "fields", NAME_FIELDS ), query, Objects.class )
+            .addParameter( "fields", fieldsParams ), query, Objects.class )
                 .getDataElementGroups();
     }
 

--- a/src/main/java/org/hisp/dhis/model/DataElementGroup.java
+++ b/src/main/java/org/hisp/dhis/model/DataElementGroup.java
@@ -1,9 +1,20 @@
 package org.hisp.dhis.model;
 
-import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@Getter
+@Setter
 @NoArgsConstructor
 public class DataElementGroup
     extends NameableObject
 {
+    @JsonProperty
+    private List<DataElement> dataElements = new ArrayList<>();
 }

--- a/src/main/java/org/hisp/dhis/model/OrgUnitGroup.java
+++ b/src/main/java/org/hisp/dhis/model/OrgUnitGroup.java
@@ -1,11 +1,23 @@
 package org.hisp.dhis.model;
 
-import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@Getter
+@Setter
 @NoArgsConstructor
 public class OrgUnitGroup
     extends NameableObject
 {
+    @JsonProperty( "organisationUnits" )
+    private List<OrgUnit> orgUnits = new ArrayList<>();
+
     public OrgUnitGroup( String id, String name )
     {
         this.id = id;

--- a/src/test/java/org/hisp/dhis/DataElementGroupApiTest.java
+++ b/src/test/java/org/hisp/dhis/DataElementGroupApiTest.java
@@ -1,0 +1,58 @@
+package org.hisp.dhis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.model.DataElement;
+import org.hisp.dhis.model.DataElementGroup;
+import org.hisp.dhis.model.IdentifiableObject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag( "integration" )
+public class DataElementGroupApiTest
+{
+    @Test
+    void testGetDataElementGroup()
+    {
+        Dhis2 dhis2 = new Dhis2( TestFixture.DEFAULT_CONFIG );
+
+        DataElementGroup deg = dhis2.getDataElementGroup( "SriP0jBXMr6" );
+
+        assertEquals( "SriP0jBXMr6", deg.getId() );
+        assertNull( deg.getCode() );
+        assertEquals( "Lassa Fever", deg.getName() );
+        assertEquals( "Lassa Fever", deg.getShortName() );
+        assertNotNull( deg.getCreated() );
+        assertNotNull( deg.getLastUpdated() );
+        assertNull( deg.getDescription() );
+
+        // Group members assertions
+
+        List<DataElement> dataElements = deg.getDataElements();
+
+        assertNotNull( dataElements );
+        assertEquals( 3, dataElements.size() );
+
+        List<String> deIds = dataElements.stream()
+            .map( IdentifiableObject::getId )
+            .collect( Collectors.toList() );
+
+        List<String> deNames = dataElements.stream()
+            .map( IdentifiableObject::getName )
+            .collect( Collectors.toList() );
+
+        assertTrue( deIds.contains( "dVdxnTNL2jZ" ) );
+        assertTrue( deIds.contains( "NCteyX2xpMf" ) );
+        assertTrue( deIds.contains( "uz8dqEzuxyc" ) );
+
+        assertTrue( deNames.contains( "Lassa fever new" ) );
+        assertTrue( deNames.contains( "Lassa fever follow-up" ) );
+        assertTrue( deNames.contains( "Lassa fever referrals" ) );
+    }
+}

--- a/src/test/java/org/hisp/dhis/DataElementGroupsApiTest.java
+++ b/src/test/java/org/hisp/dhis/DataElementGroupsApiTest.java
@@ -1,0 +1,74 @@
+package org.hisp.dhis;
+
+import static org.hisp.dhis.util.CollectionUtils.list;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.hisp.dhis.model.DataElementGroup;
+import org.hisp.dhis.query.Filter;
+import org.hisp.dhis.query.Order;
+import org.hisp.dhis.query.Query;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag( "integration" )
+public class DataElementGroupsApiTest
+{
+    @Test
+    void testGetDataElementGroups()
+    {
+        Dhis2 dhis2 = new Dhis2( TestFixture.DEFAULT_CONFIG );
+
+        List<DataElementGroup> degs = dhis2.getDataElementGroups( Query.instance()
+            .addFilter( Filter.in( "id", list( "SriP0jBXMr6", "GBHN1a1Jddh", "b3gDdvmrSFc" ) ) )
+            .setOrder( Order.asc( "id" ) ) );
+
+        assertNotNull( degs );
+        assertEquals( 3, degs.size() );
+
+        DataElementGroup deg1 = degs.get( 0 );
+        assertEquals( "b3gDdvmrSFc", deg1.getId() );
+        assertEquals( "IDSR", deg1.getName() );
+        assertEquals( 0, deg1.getDataElements().size() );
+
+        DataElementGroup deg2 = degs.get( 1 );
+        assertEquals( "GBHN1a1Jddh", deg2.getId() );
+        assertEquals( "All Others", deg2.getName() );
+        assertEquals( 0, deg2.getDataElements().size() );
+
+        DataElementGroup deg3 = degs.get( 2 );
+        assertEquals( "SriP0jBXMr6", deg3.getId() );
+        assertEquals( "Lassa Fever", deg3.getName() );
+        assertEquals( 0, deg3.getDataElements().size() );
+    }
+
+    @Test
+    void testGetDataElementGroupsWithExpandAssociations()
+    {
+        Dhis2 dhis2 = new Dhis2( TestFixture.DEFAULT_CONFIG );
+
+        List<DataElementGroup> degs = dhis2.getDataElementGroups( Query.instance().withExpandAssociations()
+            .addFilter( Filter.in( "id", list( "SriP0jBXMr6", "GBHN1a1Jddh", "b3gDdvmrSFc" ) ) )
+            .setOrder( Order.asc( "id" ) ) );
+
+        assertNotNull( degs );
+        assertEquals( 3, degs.size() );
+
+        DataElementGroup deg1 = degs.get( 0 );
+        assertEquals( "b3gDdvmrSFc", deg1.getId() );
+        assertEquals( "IDSR", deg1.getName() );
+        assertEquals( 5, deg1.getDataElements().size() );
+
+        DataElementGroup deg2 = degs.get( 1 );
+        assertEquals( "GBHN1a1Jddh", deg2.getId() );
+        assertEquals( "All Others", deg2.getName() );
+        assertEquals( 1, deg2.getDataElements().size() );
+        assertEquals( "qrur9Dvnyt5", deg2.getDataElements().get( 0 ).getId() );
+
+        DataElementGroup deg3 = degs.get( 2 );
+        assertEquals( "SriP0jBXMr6", deg3.getId() );
+        assertEquals( "Lassa Fever", deg3.getName() );
+        assertEquals( 3, deg3.getDataElements().size() );
+    }
+}

--- a/src/test/java/org/hisp/dhis/OrgUnitGroupApiTest.java
+++ b/src/test/java/org/hisp/dhis/OrgUnitGroupApiTest.java
@@ -1,0 +1,43 @@
+package org.hisp.dhis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import org.hisp.dhis.model.OrgUnit;
+import org.hisp.dhis.model.OrgUnitGroup;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag( "integration" )
+public class OrgUnitGroupApiTest
+{
+    @Test
+    void testGetOrgUnitGroup()
+    {
+        Dhis2 dhis2 = new Dhis2( TestFixture.DEFAULT_CONFIG );
+
+        OrgUnitGroup oug = dhis2.getOrgUnitGroup( "RpbiCJpIYEj" );
+
+        assertEquals( "RpbiCJpIYEj", oug.getId() );
+        assertEquals( "Country", oug.getName() );
+        assertEquals( "Country", oug.getShortName() );
+        assertEquals( "Country", oug.getCode() );
+        assertNotNull( oug.getCreated() );
+        assertNotNull( oug.getLastUpdated() );
+        assertNull( oug.getDescription() );
+
+        // Group members assertions
+
+        List<OrgUnit> orgUnits = oug.getOrgUnits();
+
+        assertNotNull( orgUnits );
+        assertEquals( 1, orgUnits.size() );
+
+        assertEquals( "ImspTQPwCqd", orgUnits.get( 0 ).getId() );
+        assertEquals( "Sierra Leone", orgUnits.get( 0 ).getName() );
+        assertEquals( "OU_525", orgUnits.get( 0 ).getCode() );
+    }
+}

--- a/src/test/java/org/hisp/dhis/OrgUnitGroupsApiTest.java
+++ b/src/test/java/org/hisp/dhis/OrgUnitGroupsApiTest.java
@@ -1,0 +1,73 @@
+package org.hisp.dhis;
+
+import static org.hisp.dhis.util.CollectionUtils.list;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.hisp.dhis.model.OrgUnitGroup;
+import org.hisp.dhis.query.Filter;
+import org.hisp.dhis.query.Order;
+import org.hisp.dhis.query.Query;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag( "integration" )
+public class OrgUnitGroupsApiTest
+{
+    @Test
+    void testGetOrgUnitGroups()
+    {
+        Dhis2 dhis2 = new Dhis2( TestFixture.DEFAULT_CONFIG );
+
+        List<OrgUnitGroup> ougs = dhis2.getOrgUnitGroups( Query.instance()
+            .addFilter( Filter.in( "id", list( "nlX2VoouN63", "RpbiCJpIYEj", "J40PpdN4Wkk" ) ) )
+            .setOrder( Order.asc( "id" ) ) );
+
+        assertNotNull( ougs );
+        assertEquals( 3, ougs.size() );
+
+        OrgUnitGroup oug1 = ougs.get( 0 );
+        assertEquals( "J40PpdN4Wkk", oug1.getId() );
+        assertEquals( "Northern Area", oug1.getName() );
+        assertEquals( 0, oug1.getOrgUnits().size() );
+
+        OrgUnitGroup oug2 = ougs.get( 1 );
+        assertEquals( "nlX2VoouN63", oug2.getId() );
+        assertEquals( "Eastern Area", oug2.getName() );
+        assertEquals( 0, oug2.getOrgUnits().size() );
+
+        OrgUnitGroup oug3 = ougs.get( 2 );
+        assertEquals( "RpbiCJpIYEj", oug3.getId() );
+        assertEquals( "Country", oug3.getName() );
+        assertEquals( 0, oug3.getOrgUnits().size() );
+    }
+
+    @Test
+    void testGetOrgUnitGroupsWithExpandAssociations()
+    {
+        Dhis2 dhis2 = new Dhis2( TestFixture.DEFAULT_CONFIG );
+
+        List<OrgUnitGroup> ougs = dhis2.getOrgUnitGroups( Query.instance().withExpandAssociations()
+            .addFilter( Filter.in( "id", list( "nlX2VoouN63", "RpbiCJpIYEj", "J40PpdN4Wkk" ) ) )
+            .setOrder( Order.asc( "id" ) ) );
+
+        assertNotNull( ougs );
+        assertEquals( 3, ougs.size() );
+
+        OrgUnitGroup oug1 = ougs.get( 0 );
+        assertEquals( "J40PpdN4Wkk", oug1.getId() );
+        assertEquals( "Northern Area", oug1.getName() );
+        assertEquals( 4, oug1.getOrgUnits().size() );
+
+        OrgUnitGroup oug2 = ougs.get( 1 );
+        assertEquals( "nlX2VoouN63", oug2.getId() );
+        assertEquals( "Eastern Area", oug2.getName() );
+        assertEquals( 3, oug2.getOrgUnits().size() );
+
+        OrgUnitGroup oug3 = ougs.get( 2 );
+        assertEquals( "RpbiCJpIYEj", oug3.getId() );
+        assertEquals( "Country", oug3.getName() );
+        assertEquals( 1, oug3.getOrgUnits().size() );
+    }
+}

--- a/src/test/java/org/hisp/dhis/OrgUnitsApiTest.java
+++ b/src/test/java/org/hisp/dhis/OrgUnitsApiTest.java
@@ -64,7 +64,7 @@ public class OrgUnitsApiTest
     }
 
     @Test
-    void testSaveAndUpdateOrgUnitswithUids()
+    void testSaveAndUpdateOrgUnitsWithUids()
     {
         Dhis2 dhis2 = new Dhis2( TestFixture.DEFAULT_CONFIG );
 


### PR DESCRIPTION
This PR extends the `DataElementGroup` and `OrgUnitGroup` models to include their respective group members. 