### PR TITLE
chore: Adapt to Sonatype Central Publisher Portal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
@@ -20,15 +20,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
+
       - name: Release Maven package
-        uses: samuelmeuli/action-maven-publish@v1
-        with:
-          nexus_username: ${{ secrets.SONATYPE_OSSRH_USERNAME }}
-          nexus_password: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
-          maven_profiles: "branch"
+        env:
+          SONATYPE_PORTAL_USERNAME: ${{ secrets.SONATYPE_PORTAL_USERNAME }}
+          SONATYPE_PORTAL_PASSWORD: ${{ secrets.SONATYPE_PORTAL_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          GPG_SECRET_KEYS: ${{ secrets.PGP_PRIVATE_KEY }}
+        run: |
+          echo -e "$GPG_SECRET_KEYS" | gpg --import --no-tty --batch --yes
+          mvn clean deploy --settings .mvn/settings.xml -Dgpg.skip=false -Dmaven.test.skip=true -B

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,13 +29,16 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
+
       - name: Remove snapshot
         run: mvn -B versions:set -DremoveSnapshot -DgenerateBackupPoms=false
+
       - name: Release Maven package
-        uses: samuelmeuli/action-maven-publish@v1
-        with:
-          gpg_private_key: ${{ secrets.PGP_PRIVATE_KEY }}
-          gpg_passphrase: ${{ secrets.PGP_PASSPHRASE }}
-          nexus_username: ${{ secrets.SONATYPE_OSSRH_USERNAME }}
-          nexus_password: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
-          maven_profiles: "deploy"
+        env:
+          SONATYPE_PORTAL_USERNAME: ${{ secrets.SONATYPE_PORTAL_USERNAME }}
+          SONATYPE_PORTAL_PASSWORD: ${{ secrets.SONATYPE_PORTAL_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          GPG_SECRET_KEYS: ${{ secrets.PGP_PRIVATE_KEY }}
+        run: |
+          echo -e "$GPG_SECRET_KEYS" | gpg --import --no-tty --batch --yes
+          mvn clean deploy --settings .mvn/settings.xml -Dgpg.skip=false -Dmaven.test.skip=true -B

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <servers>
+        <server>
+            <id>central</id>
+            <username>${env.SONATYPE_PORTAL_USERNAME}</username>
+            <password>${env.SONATYPE_PORTAL_PASSWORD}</password>
+        </server>
+    </servers>
+
+    <profiles>
+        <profile>
+            <id>central</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <gpg.executable>gpg</gpg.executable>
+                <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+            </properties>
+        </profile>
+    </profiles>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <!--
-    Update version only to deploy new version to Maven central. Avoid using a SNAPHSHOT version as 
+    Update version only to deploy new version to Maven central. Avoid using a SNAPHSHOT version as
     GitHub Action will remove it before deployment.
   -->
   <groupId>org.hisp</groupId>
   <artifactId>dhis2-java-client</artifactId>
-  <version>2.2.5</version>
+  <version>2.2.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>DHIS 2 API client for Java</name>
@@ -47,17 +47,6 @@
     <url>https://github.com/dhis2/dhis2-java-client</url>
   </issueManagement>
 
-  <distributionManagement>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -77,6 +66,7 @@
     <commons-collections4.version>4.5.0</commons-collections4.version>
     <commons-codec.version>1.18.0</commons-codec.version>
     <spotless.version>2.44.3</spotless.version>
+    <gpg.skip>true</gpg.skip>
   </properties>
 
   <dependencies>
@@ -187,9 +177,9 @@
         <enabled>true</enabled>
         <updatePolicy>always</updatePolicy>
       </snapshots>
-      <id>ossrh</id>
-      <name>Sonatype OSS</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>PortalSnapshots</id>
+      <name>Maven Portal Snapshots</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </repository>
   </repositories>
 
@@ -274,6 +264,36 @@
           <lineEndings>UNIX</lineEndings>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>3.0.1</version>
+        <configuration>
+          <gpgArguments>
+            <arg>--pinentry-mode</arg>
+            <arg>loopback</arg>
+          </gpgArguments>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
+          <deploymentName>DHIS2 Java Client</deploymentName>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -292,103 +312,6 @@
       <properties>
         <test.excluded.groups/>
       </properties>
-    </profile>
-    <profile>
-      <id>branch</id>
-      <properties>
-        <test.excluded.groups>integration</test.excluded.groups>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <version>3.5.0</version>
-            <executions>
-              <execution>
-                <id>enforce-no-releases</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules>
-                    <requireSnapshotVersion>
-                      <message>No Releases Allowed!</message>
-                    </requireSnapshotVersion>
-                  </rules>
-                  <fail>true</fail>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <!-- Profile used for OSSHR deployment -->
-      <!-- See file 'master.yml' and property 'maven_profiles' -->
-      <id>deploy</id>
-      <properties>
-        <test.excluded.groups>integration</test.excluded.groups>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <version>3.5.0</version>
-            <executions>
-              <execution>
-                <id>enforce-no-snapshots</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules>
-                    <requireReleaseVersion>
-                      <message>No Snapshots Allowed!</message>
-                    </requireReleaseVersion>
-                  </rules>
-                  <fail>true</fail>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-              <stagingProgressTimeoutMinutes>20</stagingProgressTimeoutMinutes>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <phase>verify</phase>
-                <!-- Prevent gpg from using pinentry programs -->
-                <configuration>
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 


### PR DESCRIPTION
This PR is in draft because it modifies the existing behavior.

Before this PR, both workflows (pull-request and main) will try to publish the artifact, but the pull-request worflow will always fail because the version does not contain the "-SNAPSHOT" suffix and there was a rule to enforce that artifacts published in a non-main branch must have the suffix.

There are two options to move on:
1. If we don't want SNAPSHOT publication on each pull request, we can just remove the publication step in the pull-request workflow.
2. If we want SNAPSHOT publications on each pull request, we can add the "-SNAPSHOT" suffix to the version. This suffix will be automatically removed when publishing from the main branch.

At this moment, this PR implements option 2. 