### PR TITLE
fix: Handle unauthorized status when connecting with cookie

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Contains constants for DHIS2 API paths and field sets used when constructing req
 ## Key Dependencies
 
 - **Apache HttpComponents Client 5** — HTTP transport
-- **Jackson 2** — JSON serialization/deserialization (`JacksonUtils` in `util/`)
+- **Jackson 3** (`tools.jackson`) — JSON/XML/YAML serialization (`JacksonUtils` in `util/`)
 - **Lombok** — reduces boilerplate on model classes
 - **JTS** — geometry/spatial types for GeoJSON
 - **SLF4J** — logging facade

--- a/src/main/java/org/hisp/dhis/BaseDhis2.java
+++ b/src/main/java/org/hisp/dhis/BaseDhis2.java
@@ -174,7 +174,7 @@ public class BaseDhis2 {
     Objects.requireNonNull(config, "Config must be specified");
     this.config = config;
     this.jsonMapper = JacksonUtils.getJsonMapper();
-    this.httpClient = HttpClients.createDefault();
+    this.httpClient = HttpClients.custom().disableRedirectHandling().build();
   }
 
   /**
@@ -1139,7 +1139,11 @@ public class BaseDhis2 {
    * @throws Dhis2ClientException in the case of error status codes.
    */
   private void handleErrors(HttpResponse response, String url) {
-    final int code = response.getCode();
+    int code = response.getCode();
+
+    if (redirectedToLogin(response)) {
+      code = HttpStatus.UNAUTHORIZED.value();
+    }
 
     if (ERROR_STATUS_CODES.contains(code)) {
       String message = String.format("%s (%d)", getErrorMessage(code), code);
@@ -1438,6 +1442,21 @@ public class BaseDhis2 {
             : Status.ERROR;
 
     return new Response(status, response.getHttpStatusCode(), response.getMessage());
+  }
+
+  /**
+   * Checks whether the response redirects to the DHIS2 login page.
+   *
+   * @param response the HTTP response
+   * @return {@code true} if the response is a login redirect, otherwise {@code false}
+   */
+  protected boolean redirectedToLogin(HttpResponse response) {
+    if (!HttpStatus.valueOf(response.getCode()).is3xxRedirection()) {
+      return false;
+    }
+
+    final Header locationHeader = response.getLastHeader(HttpHeaders.LOCATION);
+    return locationHeader != null && locationHeader.getValue().contains("dhis-web-login");
   }
 
   /**

--- a/src/main/java/org/hisp/dhis/BaseDhis2.java
+++ b/src/main/java/org/hisp/dhis/BaseDhis2.java
@@ -1451,7 +1451,7 @@ public class BaseDhis2 {
    * @return {@code true} if the response is a login redirect, otherwise {@code false}
    */
   protected boolean redirectedToLogin(HttpResponse response) {
-    if (!HttpStatus.valueOf(response.getCode()).is3xxRedirection()) {
+    if (HttpStatus.FOUND.value() != response.getCode()) {
       return false;
     }
 

--- a/src/main/java/org/hisp/dhis/Dhis2.java
+++ b/src/main/java/org/hisp/dhis/Dhis2.java
@@ -306,6 +306,11 @@ public class Dhis2 extends BaseDhis2 {
           request,
           response -> {
             int statusCode = response.getCode();
+
+            if (redirectedToLogin(response)) {
+              statusCode = HttpStatus.UNAUTHORIZED.value();
+            }
+
             return HttpStatus.valueOf(statusCode);
           });
     } catch (IOException ex) {

--- a/src/test/java/org/hisp/dhis/BaseDhis2Test.java
+++ b/src/test/java/org/hisp/dhis/BaseDhis2Test.java
@@ -27,8 +27,7 @@
  */
 package org.hisp.dhis;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.net.URI;
@@ -39,6 +38,8 @@ import org.hisp.dhis.model.DataDomain;
 import org.hisp.dhis.model.DataElement;
 import org.hisp.dhis.model.ValueType;
 import org.hisp.dhis.query.analytics.AnalyticsQuery;
+import org.hisp.dhis.response.Dhis2ClientException;
+import org.hisp.dhis.response.HttpStatus;
 import org.hisp.dhis.support.TestTags;
 import org.hisp.dhis.util.CodecUtils;
 import org.junit.jupiter.api.Tag;
@@ -150,5 +151,16 @@ class BaseDhis2Test {
             TestFixture.DEFAULT_URL);
 
     assertEquals(expected, decodedUrl);
+  }
+
+  @Test
+  void testWithInvalidSessionIdReturnsUnauthorized() {
+    Dhis2 dhis2 = Dhis2.withCookieAuth(TestFixture.DEFAULT_URL, "InvalidSessionId");
+
+    Dhis2ClientException ex = assertThrows(Dhis2ClientException.class, dhis2::getSystemInfo);
+    assertNotNull(ex);
+    assertEquals(HttpStatus.UNAUTHORIZED, ex.getHttpStatus());
+
+    assertEquals(HttpStatus.UNAUTHORIZED, dhis2.getStatus());
   }
 }


### PR DESCRIPTION
  When a CookieAuthentication session expires, DHIS2 responds with a 3xx redirect to the login page rather than a 401 Unauthorized. The HTTP client was previously following redirects automatically, which caused the subsequent request to the login page to succeed with a 200 OK — masking the authentication failure entirely.

  This PR fixes that by:

  - Disabling automatic redirect following on the HttpClient (disableRedirectHandling()).
  - Detecting 3xx responses whose Location header contains dhis-web-login and converting them to 401 Unauthorized before error handling runs.

  The result is that callers now receive a Dhis2ClientException with isUnauthorized() == true when a cookie session expires, which is the correct and expected behavior.

