### PR TITLE
feat: Add transfer tracked entity program owner OrgUnit

### DIFF
--- a/src/main/java/org/hisp/dhis/Dhis2.java
+++ b/src/main/java/org/hisp/dhis/Dhis2.java
@@ -45,8 +45,10 @@ import static org.hisp.dhis.api.ApiPaths.PATH_ENROLLMENTS;
 import static org.hisp.dhis.api.ApiPaths.PATH_EVENTS;
 import static org.hisp.dhis.api.ApiPaths.PATH_FILE_RESOURCES;
 import static org.hisp.dhis.api.ApiPaths.PATH_METADATA;
+import static org.hisp.dhis.api.ApiPaths.PATH_OWNERSHIP;
 import static org.hisp.dhis.api.ApiPaths.PATH_TRACKED_ENTITIES;
 import static org.hisp.dhis.api.ApiPaths.PATH_TRACKER;
+import static org.hisp.dhis.api.ApiPaths.PATH_TRANSFER;
 import static org.hisp.dhis.util.CollectionUtils.asList;
 import static org.hisp.dhis.util.CollectionUtils.list;
 import static org.hisp.dhis.util.IdentifiableObjectUtils.toIdObjects;
@@ -56,6 +58,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -70,6 +73,7 @@ import org.apache.commons.lang3.Validate;
 import org.apache.hc.client5.http.HttpResponseException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
@@ -4591,6 +4595,39 @@ public class Dhis2 extends BaseDhis2 {
             .appendPath(PATH_TRACKED_ENTITIES)
             .addParameter(FIELDS_PARAM, TRACKED_ENTITY_FIELDS),
         query);
+  }
+
+  /**
+   * Transfers the ownership org unit of a tracked entity for the given program.
+   *
+   * @param trackedEntity the tracked entity identifier.
+   * @param program the program identifier.
+   * @param orgUnit the identifier of the org unit to transfer ownership to.
+   * @return the {@link Response}.
+   */
+  public Response transferTrackedEntityProgramOwnerOrgUnit(
+      String trackedEntity, String program, String orgUnit) {
+    Objects.requireNonNull(trackedEntity, "trackedEntity must be specified");
+    Objects.requireNonNull(program, "program must be specified");
+    Objects.requireNonNull(orgUnit, "orgUnit must be specified");
+    SystemInfo systemInfo = getSystemInfo();
+    try {
+      URIBuilder builder =
+          config
+              .getResolvedUriBuilder()
+              .appendPath(PATH_TRACKER)
+              .appendPath(PATH_OWNERSHIP)
+              .appendPath(PATH_TRANSFER)
+              .addParameter("program", program);
+      if (systemInfo.getSystemVersion().isHigherOrEqual("2.42")) {
+        builder.addParameter("trackedEntity", trackedEntity).addParameter("orgUnit", program);
+      } else {
+        builder.addParameter("trackedEntityInstance", trackedEntity).addParameter("ou", orgUnit);
+      }
+      return executeRequest(new HttpPut(builder.build()), Response.class);
+    } catch (URISyntaxException ex) {
+      throw new Dhis2ClientException("Invalid URI syntax", ex);
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/main/java/org/hisp/dhis/Dhis2.java
+++ b/src/main/java/org/hisp/dhis/Dhis2.java
@@ -4620,7 +4620,7 @@ public class Dhis2 extends BaseDhis2 {
               .appendPath(PATH_TRANSFER)
               .addParameter("program", program);
       if (systemInfo.getSystemVersion().isHigherOrEqual("2.42")) {
-        builder.addParameter("trackedEntity", trackedEntity).addParameter("orgUnit", program);
+        builder.addParameter("trackedEntity", trackedEntity).addParameter("orgUnit", orgUnit);
       } else {
         builder.addParameter("trackedEntityInstance", trackedEntity).addParameter("ou", orgUnit);
       }

--- a/src/main/java/org/hisp/dhis/api/ApiPaths.java
+++ b/src/main/java/org/hisp/dhis/api/ApiPaths.java
@@ -35,11 +35,17 @@ public class ApiPaths {
   /** Metadata API path. */
   public static final String PATH_METADATA = "metadata";
 
-  /** Tracker API path. */
+  /** Events API path. */
   public static final String PATH_EVENTS = "events";
 
   /** Tracker API path. */
   public static final String PATH_TRACKER = "tracker";
+
+  /** Ownership API path. */
+  public static final String PATH_OWNERSHIP = "ownership";
+
+  /** Transfer API path. */
+  public static final String PATH_TRANSFER = "transfer";
 
   /** Tracked entities API path. */
   public static final String PATH_TRACKED_ENTITIES = "trackedEntities";
@@ -47,7 +53,7 @@ public class ApiPaths {
   /** Enrollments API path. */
   public static final String PATH_ENROLLMENTS = "enrollments";
 
-  /** Tracker API path. */
+  /** File resources API path. */
   public static final String PATH_FILE_RESOURCES = "fileResources";
 
   /** Analytics API path. */

--- a/src/test/java/org/hisp/dhis/TestFixture.java
+++ b/src/test/java/org/hisp/dhis/TestFixture.java
@@ -40,7 +40,7 @@ public final class TestFixture {
 
   public static final String V41_URL = "https://play.im.dhis2.org/stable-2-41-9";
 
-  public static final String V42_URL = "https://play.im.dhis2.org/stable-2-42-4-1";
+  public static final String V42_URL = "https://play.im.dhis2.org/stable-2-42-5-1";
 
   public static final String LOCAL_URL = "http://localhost/dhis";
 

--- a/src/test/java/org/hisp/dhis/TrackedEntityApiTest.java
+++ b/src/test/java/org/hisp/dhis/TrackedEntityApiTest.java
@@ -30,14 +30,20 @@ package org.hisp.dhis;
 import static org.hisp.dhis.support.Assertions.assertNotEmpty;
 import static org.hisp.dhis.support.Assertions.assertSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
+import org.hisp.dhis.model.enrollment.Enrollment;
+import org.hisp.dhis.model.enrollment.EnrollmentStatus;
 import org.hisp.dhis.model.trackedentity.TrackedEntitiesResult;
 import org.hisp.dhis.model.trackedentity.TrackedEntity;
 import org.hisp.dhis.query.Filter;
 import org.hisp.dhis.query.Paging;
 import org.hisp.dhis.query.trackedentity.TrackedEntityQuery;
+import org.hisp.dhis.response.HttpStatus;
+import org.hisp.dhis.response.Response;
+import org.hisp.dhis.response.Status;
 import org.hisp.dhis.support.TestTags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -118,5 +124,28 @@ class TrackedEntityApiTest {
     assertNotNull(trackedEntities);
     assertNotEmpty(trackedEntities.getTrackedEntities());
     assertSize(2, trackedEntities.getTrackedEntities());
+  }
+
+  @Test
+  void testTransferTrackedEntityProgramOwnerOrgUnit() {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+
+    TrackedEntity trackedEntity = dhis2.getTrackedEntity("kfwLSxq7mXk");
+
+    assertNotNull(trackedEntity);
+    assertFalse(trackedEntity.getEnrollments().isEmpty());
+    Enrollment enrollment =
+        trackedEntity.getEnrollments().stream()
+            .filter(e -> e.getStatus() == EnrollmentStatus.ACTIVE)
+            .findFirst()
+            .orElse(null);
+
+    Response response =
+        dhis2.transferTrackedEntityProgramOwnerOrgUnit(
+            trackedEntity.getTrackedEntity(), enrollment.getProgram(), enrollment.getOrgUnit());
+
+    assertEquals(200, response.getHttpStatusCode().intValue(), response.toString());
+    assertEquals(HttpStatus.OK, response.getHttpStatus(), response.toString());
+    assertEquals(Status.OK, response.getStatus(), response.toString());
   }
 }


### PR DESCRIPTION
  - Adds Dhis2.transferTrackedEntityProgramOwnerOrgUnit(trackedEntity, program, orgUnit), which calls PUT /api/tracker/ownership/transfer to transfer the ownership org unit of a tracked entity for a given program.                                                                                                                                         
  - The endpoint's query parameter names changed between DHIS2 versions, so the method checks SystemInfo.getSystemVersion() and uses trackedEntity/orgUnit for DHIS2 ≥ 2.42, and trackedEntityInstance/ou for earlier versions.  