### PR TITLE
feat: Add Option Group API support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.hisp</groupId>
   <artifactId>dhis2-java-client</artifactId>
-  <version>2.7.5</version>
+  <version>2.7.6</version>
   <packaging>jar</packaging>
 
   <name>DHIS 2 API client for Java</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.hisp</groupId>
   <artifactId>dhis2-java-client</artifactId>
-  <version>2.7.4</version>
+  <version>2.7.5</version>
   <packaging>jar</packaging>
 
   <name>DHIS 2 API client for Java</name>

--- a/src/main/java/org/hisp/dhis/Dhis2.java
+++ b/src/main/java/org/hisp/dhis/Dhis2.java
@@ -111,6 +111,7 @@ import org.hisp.dhis.model.IndicatorGroupSet;
 import org.hisp.dhis.model.IndicatorType;
 import org.hisp.dhis.model.Me;
 import org.hisp.dhis.model.Option;
+import org.hisp.dhis.model.OptionGroup;
 import org.hisp.dhis.model.OptionSet;
 import org.hisp.dhis.model.OptionSetObjects;
 import org.hisp.dhis.model.OrgUnit;
@@ -2803,6 +2804,61 @@ public class Dhis2 extends BaseDhis2 {
    */
   public Metadata<Option> getOptionsPaged(Query query) {
     return getMetadata(MetadataEntity.OPTION, query);
+  }
+
+  // -------------------------------------------------------------------------
+  // OptionGroup
+  // -------------------------------------------------------------------------
+
+  /**
+   * Retrieves an {@link OptionGroup}.
+   *
+   * @param id the object identifier.
+   * @return the {@link OptionGroup}.
+   * @throws Dhis2ClientException if the object does not exist.
+   */
+  public OptionGroup getOptionGroup(String id) {
+    return getMetadataObject(MetadataEntity.OPTION_GROUP, id);
+  }
+
+  /**
+   * Indicates whether a {@link OptionGroup} exists.
+   *
+   * @param id the object identifier.
+   * @return true if the object exists.
+   */
+  public boolean isOptionGroup(String id) {
+    return objectExists(MetadataEntity.OPTION_GROUP, id);
+  }
+
+  /**
+   * Retrieves a list of {@link OptionGroup}.
+   *
+   * @param query the {@link Query}.
+   * @return list of {@link OptionGroup}.
+   */
+  public List<OptionGroup> getOptionGroups(Query query) {
+    return getMetadataList(MetadataEntity.OPTION_GROUP, query);
+  }
+
+  /**
+   * Retrieves a {@link Metadata} of type {@link OptionGroup}.
+   *
+   * @param query the {@link Query}.
+   * @return a {@link Metadata}.
+   */
+  public Metadata<OptionGroup> getOptionGroupsPaged(Query query) {
+    return getMetadata(MetadataEntity.OPTION_GROUP, query);
+  }
+
+  /**
+   * Removes an {@link OptionGroup}.
+   *
+   * @param id the identifier of the object to remove.
+   * @return {@link ObjectResponse} holding information about the operation.
+   */
+  public ObjectResponse removeOptionGroup(String id) {
+    return removeMetadataObject(MetadataEntity.OPTION_GROUP, id);
   }
 
   // -------------------------------------------------------------------------

--- a/src/main/java/org/hisp/dhis/api/ApiFields.java
+++ b/src/main/java/org/hisp/dhis/api/ApiFields.java
@@ -115,6 +115,14 @@ public class ApiFields {
   public static final String OPTION_EXT_FIELDS =
       String.format("%1$s,sortOrder,optionSet[%2$s]", NAME_EXT_FIELDS, ID_FIELDS);
 
+  /** Option group fields. */
+  public static final String OPTION_GROUP_FIELDS =
+      String.format("%1$s,options[%2$s],optionSet[%2$s]", NAME_FIELDS, ID_FIELDS);
+
+  /** Option group extended fields. */
+  public static final String OPTION_GROUP_EXT_FIELDS =
+      String.format("%1$s,options[%2$s],optionSet[%2$s]", NAME_EXT_FIELDS, ID_FIELDS);
+
   /** Option set fields. */
   public static final String OPTION_SET_FIELDS =
       String.format("%s,valueType,version", ID_EXT_FIELDS);
@@ -406,7 +414,7 @@ public class ApiFields {
           """
           %1$s,programRule[%2$s],programRuleActionType,dataElement[%2$s],trackedEntityAttribute[%2$s],\
           programIndicator[%2$s],programStageSection[%2$s],programStage[%2$s],option[%2$s],\
-          location,content,data""",
+          optionGroup[%2$s],location,content,data""",
           ID_EXT_FIELDS, ID_FIELDS);
 
   public static final String PROGRAM_RULE_FIELDS =

--- a/src/main/java/org/hisp/dhis/model/Dhis2Objects.java
+++ b/src/main/java/org/hisp/dhis/model/Dhis2Objects.java
@@ -118,11 +118,13 @@ public class Dhis2Objects implements Serializable {
 
   @JsonProperty private List<OrgUnitLevel> organisationUnitLevels = new ArrayList<>();
 
-  @JsonProperty private List<GeoMap> maps = new ArrayList<GeoMap>();
+  @JsonProperty private List<GeoMap> maps = new ArrayList<>();
 
   @JsonProperty private List<OptionSet> optionSets = new ArrayList<>();
 
   @JsonProperty private List<Option> options = new ArrayList<>();
+
+  @JsonProperty private List<OptionGroup> optionGroups = new ArrayList<>();
 
   @JsonProperty private List<Program> programs = new ArrayList<>();
 

--- a/src/main/java/org/hisp/dhis/model/OptionGroup.java
+++ b/src/main/java/org/hisp/dhis/model/OptionGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,34 +27,25 @@
  */
 package org.hisp.dhis.model;
 
-import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.Accessors;
+import org.hisp.dhis.model.dimension.DimensionItem;
+import org.hisp.dhis.model.dimension.DimensionItemType;
 
 @Getter
 @Setter
-@Accessors(chain = true)
 @NoArgsConstructor
-public class OptionSetObjects implements Serializable {
-  @JsonProperty private List<OptionSet> optionSets = new ArrayList<>();
+public class OptionGroup extends DimensionItem {
+  @JsonProperty private Set<Option> options = new HashSet<>();
 
-  @JsonProperty private List<Option> options = new ArrayList<>();
+  @JsonProperty private OptionSet optionSet;
 
-  @JsonProperty private List<OptionGroup> optionGroups = new ArrayList<>();
-
-  /**
-   * Returns the first option in the list of options, or null if no options exist.
-   *
-   * @return the first option, or null.
-   */
-  public OptionSet getFirstOptionSet() {
-    return isNotEmpty(optionSets) ? optionSets.get(0) : null;
+  @Override
+  public DimensionItemType getDimensionItemType() {
+    return DimensionItemType.OPTION_GROUP;
   }
 }

--- a/src/main/java/org/hisp/dhis/model/metadata/MetadataEntity.java
+++ b/src/main/java/org/hisp/dhis/model/metadata/MetadataEntity.java
@@ -59,6 +59,8 @@ import static org.hisp.dhis.api.ApiFields.INDICATOR_TYPE_FIELDS;
 import static org.hisp.dhis.api.ApiFields.MAP_FIELDS;
 import static org.hisp.dhis.api.ApiFields.OPTION_EXT_FIELDS;
 import static org.hisp.dhis.api.ApiFields.OPTION_FIELDS;
+import static org.hisp.dhis.api.ApiFields.OPTION_GROUP_EXT_FIELDS;
+import static org.hisp.dhis.api.ApiFields.OPTION_GROUP_FIELDS;
 import static org.hisp.dhis.api.ApiFields.OPTION_SET_EXT_FIELDS;
 import static org.hisp.dhis.api.ApiFields.OPTION_SET_FIELDS;
 import static org.hisp.dhis.api.ApiFields.ORG_UNIT_FIELDS;
@@ -115,6 +117,7 @@ import org.hisp.dhis.model.IndicatorGroup;
 import org.hisp.dhis.model.IndicatorGroupSet;
 import org.hisp.dhis.model.IndicatorType;
 import org.hisp.dhis.model.Option;
+import org.hisp.dhis.model.OptionGroup;
 import org.hisp.dhis.model.OptionSet;
 import org.hisp.dhis.model.OrgUnit;
 import org.hisp.dhis.model.OrgUnitGroup;
@@ -330,6 +333,12 @@ public enum MetadataEntity {
       OPTION_EXT_FIELDS,
       "options",
       Dhis2Objects::getOptions),
+  OPTION_GROUP(
+      OptionGroup.class,
+      OPTION_GROUP_FIELDS,
+      OPTION_GROUP_EXT_FIELDS,
+      "optionGroups",
+      Dhis2Objects::getOptionGroups),
   PROGRAM(
       Program.class,
       PROGRAM_MIN_FIELDS,
@@ -503,6 +512,8 @@ public enum MetadataEntity {
       return OPTION_SET;
     } else if (object instanceof Option) {
       return OPTION;
+    } else if (object instanceof OptionGroup) {
+      return OPTION_GROUP;
     } else if (object instanceof Program) {
       return PROGRAM;
     } else if (object instanceof ProgramSection) {

--- a/src/main/java/org/hisp/dhis/model/programrule/ProgramRuleAction.java
+++ b/src/main/java/org/hisp/dhis/model/programrule/ProgramRuleAction.java
@@ -31,12 +31,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hisp.dhis.model.DataElement;
-import org.hisp.dhis.model.IdentifiableObject;
-import org.hisp.dhis.model.Option;
-import org.hisp.dhis.model.ProgramIndicator;
-import org.hisp.dhis.model.ProgramStage;
-import org.hisp.dhis.model.ProgramStageSection;
+import org.hisp.dhis.model.*;
 import org.hisp.dhis.model.trackedentity.TrackedEntityAttribute;
 
 @Getter
@@ -64,4 +59,6 @@ public class ProgramRuleAction extends IdentifiableObject {
   @JsonProperty private String data;
 
   @JsonProperty private Option option;
+
+  @JsonProperty private OptionGroup optionGroup;
 }

--- a/src/main/java/org/hisp/dhis/model/programrule/ProgramRuleAction.java
+++ b/src/main/java/org/hisp/dhis/model/programrule/ProgramRuleAction.java
@@ -31,7 +31,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hisp.dhis.model.*;
+import org.hisp.dhis.model.DataElement;
+import org.hisp.dhis.model.IdentifiableObject;
+import org.hisp.dhis.model.Option;
+import org.hisp.dhis.model.OptionGroup;
+import org.hisp.dhis.model.ProgramIndicator;
+import org.hisp.dhis.model.ProgramStage;
+import org.hisp.dhis.model.ProgramStageSection;
 import org.hisp.dhis.model.trackedentity.TrackedEntityAttribute;
 
 @Getter

--- a/src/test/java/org/hisp/dhis/OptionGroupApiTest.java
+++ b/src/test/java/org/hisp/dhis/OptionGroupApiTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis;
+
+import static org.hisp.dhis.support.Assertions.assertSuccessResponse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import org.hisp.dhis.model.Option;
+import org.hisp.dhis.model.OptionGroup;
+import org.hisp.dhis.model.OptionSet;
+import org.hisp.dhis.response.HttpStatus;
+import org.hisp.dhis.response.Status;
+import org.hisp.dhis.response.object.ObjectResponse;
+import org.hisp.dhis.support.TestTags;
+import org.hisp.dhis.util.UidUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(TestTags.INTEGRATION)
+class OptionGroupApiTest {
+  private static final String OPTION_SET_ID = "VQ2lai3OfVG";
+
+  @Test
+  void testIsNotOptionGroup() {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+    assertFalse(dhis2.isOptionGroup("NOT_AN_OPTION_GROUP_ID"));
+  }
+
+  @Test
+  void testCreateGetAndDeleteOptionGroup() {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+    String uidA = UidUtils.generateUid();
+
+    OptionSet optionSet = dhis2.getOptionSet(OPTION_SET_ID);
+    assertNotNull(optionSet);
+    assertFalse(optionSet.getOptions().isEmpty());
+
+    Option memberOption = new Option();
+    memberOption.setId(optionSet.getOptions().get(0).getId());
+
+    OptionSet optionSetRef = new OptionSet();
+    optionSetRef.setId(optionSet.getId());
+
+    OptionGroup optionGroup = new OptionGroup();
+    optionGroup.setId(uidA);
+    optionGroup.setName("NAME-" + uidA);
+    optionGroup.setShortName("SHORT_NAME-" + uidA);
+    optionGroup.setCode("CODE-" + uidA);
+    optionGroup.setOptionSet(optionSetRef);
+    optionGroup.setOptions(Set.of(memberOption));
+
+    // Create
+    ObjectResponse createResp = dhis2.saveMetadataObject(optionGroup);
+    assertEquals(201, createResp.getHttpStatusCode().intValue(), createResp.toString());
+    assertEquals(HttpStatus.CREATED, createResp.getHttpStatus(), createResp.toString());
+    assertEquals(Status.OK, createResp.getStatus(), createResp.toString());
+    assertNotNull(createResp.getResponse());
+    assertNotNull(createResp.getResponse().getUid());
+
+    assertTrue(dhis2.isOptionGroup(uidA));
+
+    OptionGroup savedOptionGroup = dhis2.getOptionGroup(optionGroup.getId());
+    assertNotNull(savedOptionGroup);
+    assertEquals(optionGroup.getId(), savedOptionGroup.getId());
+    assertEquals(optionGroup.getName(), savedOptionGroup.getName());
+    assertEquals(optionGroup.getCode(), savedOptionGroup.getCode());
+    assertEquals(optionGroup.getOptionSet(), savedOptionGroup.getOptionSet());
+    assertEquals(1, savedOptionGroup.getOptions().size());
+
+    // Remove
+    ObjectResponse removeRespA = dhis2.removeOptionGroup(uidA);
+    assertSuccessResponse(removeRespA, HttpStatus.OK, 200);
+  }
+}

--- a/src/test/java/org/hisp/dhis/OptionSetApiTest.java
+++ b/src/test/java/org/hisp/dhis/OptionSetApiTest.java
@@ -27,9 +27,7 @@
  */
 package org.hisp.dhis;
 
-import static org.hisp.dhis.support.Assertions.assertNotBlank;
-import static org.hisp.dhis.support.Assertions.assertNotEmpty;
-import static org.hisp.dhis.support.Assertions.assertSize;
+import static org.hisp.dhis.support.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -38,9 +36,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import org.hisp.dhis.model.Dhis2Objects;
 import org.hisp.dhis.model.Option;
+import org.hisp.dhis.model.OptionGroup;
 import org.hisp.dhis.model.OptionSet;
 import org.hisp.dhis.model.OptionSetObjects;
 import org.hisp.dhis.query.Query;
+import org.hisp.dhis.response.HttpStatus;
 import org.hisp.dhis.response.Status;
 import org.hisp.dhis.response.object.ObjectResponse;
 import org.hisp.dhis.response.objects.ObjectsResponse;
@@ -153,6 +153,11 @@ class OptionSetApiTest {
     assertNotNull(option);
     assertNotBlank(option.getId());
 
+    ObjectResponse removeGroupResponse = dhis2.removeOptionGroup("BZK0eV8dEYs");
+    assertNotNull(removeGroupResponse);
+    assertEquals(Status.OK, removeGroupResponse.getStatus());
+    assertEquals(200, removeGroupResponse.getHttpStatusCode());
+
     ObjectResponse removeResponse = dhis2.removeOptionSet("qszOn4ydMDE");
 
     assertNotNull(removeResponse);
@@ -209,11 +214,11 @@ class OptionSetApiTest {
     assertNotNull(updated.getLastUpdatedBy());
     assertSize(3, updated.getOptions());
 
-    ObjectResponse removeResponse = dhis2.removeOptionSet("qszOn4ydMDE");
+    ObjectResponse removeGroupResponse = dhis2.removeOptionGroup("BZK0eV8dEYs");
+    assertSuccessResponse(removeGroupResponse, HttpStatus.OK, 200);
 
-    assertNotNull(removeResponse);
-    assertEquals(Status.OK, removeResponse.getStatus());
-    assertEquals(200, removeResponse.getHttpStatusCode());
+    ObjectResponse removeResponse = dhis2.removeOptionSet("qszOn4ydMDE");
+    assertSuccessResponse(removeResponse, HttpStatus.OK, 200);
   }
 
   @Test
@@ -221,6 +226,7 @@ class OptionSetApiTest {
     Dhis2Objects optionSet =
         JsonClassPathFile.fromJson("metadata/option-set-color.json", Dhis2Objects.class);
 
+    assertSize(1, optionSet.getOptionGroups());
     assertSize(1, optionSet.getOptionSets());
     assertSize(3, optionSet.getOptions());
 
@@ -244,6 +250,15 @@ class OptionSetApiTest {
 
     assertNotNull(option);
     assertNotBlank(option.getId());
+
+    OptionGroup optionGroup = dhis2.getOptionGroup("BZK0eV8dEYs");
+    assertNotNull(optionGroup);
+    assertNotBlank(optionGroup.getId());
+
+    ObjectResponse removeGroupResponse = dhis2.removeOptionGroup(optionGroup.getId());
+    assertNotNull(removeGroupResponse);
+    assertEquals(Status.OK, removeGroupResponse.getStatus());
+    assertEquals(200, removeGroupResponse.getHttpStatusCode());
 
     ObjectResponse removeResponse = dhis2.removeOptionSet("qszOn4ydMDE");
 

--- a/src/test/java/org/hisp/dhis/OptionSetApiTest.java
+++ b/src/test/java/org/hisp/dhis/OptionSetApiTest.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis;
 
-import static org.hisp.dhis.support.Assertions.*;
+import static org.hisp.dhis.support.Assertions.assertNotBlank;
+import static org.hisp.dhis.support.Assertions.assertNotEmpty;
+import static org.hisp.dhis.support.Assertions.assertSize;
+import static org.hisp.dhis.support.Assertions.assertSuccessResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/resources/metadata/option-set-color.json
+++ b/src/test/resources/metadata/option-set-color.json
@@ -47,5 +47,26 @@
         "id": "qszOn4ydMDE"
       }
     }
+  ],
+  "optionGroups": [
+    {
+      "name": "RGB Color group",
+      "shortName": "RGB Color",
+      "id": "BZK0eV8dEYs",
+      "options": [
+        {
+          "id": "cszOn4ydMDE"
+        },
+        {
+          "id": "bIGx0gFo9fs"
+        },
+        {
+          "id": "aszOn4ydMDE"
+        }
+      ],
+      "optionSet": {
+        "id": "qszOn4ydMDE"
+      }
+    }
   ]
 }


### PR DESCRIPTION
- Adds OptionGroup as a new domain model (extends DimensionItem), with options (member Options) and optionSet fields.
- Adds read/remove operations to Dhis2: getOptionGroup(id), isOptionGroup(id), getOptionGroups(query), getOptionGroupsPaged(query), removeOptionGroup(id). There is no dedicated saveOptionGroup — option groups are created/updated via the generic saveMetadataObject/saveMetadataObjects paths, consistent with how Option is already handled.
- Registers OPTION_GROUP in MetadataEntity (new OPTION_GROUP_FIELDS/OPTION_GROUP_EXT_FIELDS in ApiFields), and wires Dhis2Objects/OptionSetObjects to carry an optionGroups list for bulk metadata import/export.
- Adds an optionGroup reference field to ProgramRuleAction, since program rule actions can target an option group (in addition to the existing option field).
- New OptionGroupApiTest covering isOptionGroup (negative case) and a full create → get → delete round trip against the live play instance.
- Updates OptionSetApiTest to clean up the option group (BZK0eV8dEYs) created alongside the option set fixture, and adds coverage for getOptionGroup on data imported via saveMetadataObjects.
- Updates the option-set-color.json test fixture to include a matching optionGroups entry.
- Bumps version to 2.7.6.