### PR TITLE
feat: Improve base query fields and query  pagination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.hisp</groupId>
   <artifactId>dhis2-java-client</artifactId>
-  <version>2.7.7</version>
+  <version>2.7.8</version>
   <packaging>jar</packaging>
 
   <name>DHIS 2 API client for Java</name>

--- a/src/main/java/org/hisp/dhis/BaseDhis2.java
+++ b/src/main/java/org/hisp/dhis/BaseDhis2.java
@@ -335,13 +335,16 @@ public class BaseDhis2 {
       URIBuilder uriBuilder, BaseQuery query, InternalQuery internalQuery) {
     Paging paging = query.getPaging();
 
-    if (paging.hasPaging()) {
+    if (paging != null && paging.hasPaging()) {
       if (paging.hasPage()) {
         uriBuilder.addParameter("page", String.valueOf(paging.getPage()));
       }
 
       if (paging.hasPageSize()) {
         uriBuilder.addParameter("pageSize", String.valueOf(paging.getPageSize()));
+      }
+      if (paging.isTotalPages()) {
+        uriBuilder.addParameter("totalPages", "true");
       }
     } else if (!internalQuery.isDefaultPaging()) {
       uriBuilder.addParameter("paging", "false");
@@ -556,7 +559,7 @@ public class BaseDhis2 {
     addParameter(uriBuilder, "idScheme", query.getIdScheme());
 
     addTrackerFilters(uriBuilder, query);
-    addPaging(uriBuilder, query, InternalQuery.instance());
+    addPaging(uriBuilder, query, InternalQuery.instance().withDefaultPaging());
     addOrder(uriBuilder, query);
 
     return HttpUtils.build(uriBuilder);
@@ -606,7 +609,7 @@ public class BaseDhis2 {
     addParameter(uriBuilder, "orgUnitIdScheme", query.getOrgUnitIdScheme());
 
     addTrackerFilters(uriBuilder, query);
-    addPaging(uriBuilder, query, InternalQuery.instance());
+    addPaging(uriBuilder, query, InternalQuery.instance().withDefaultPaging());
     addOrder(uriBuilder, query);
 
     return HttpUtils.build(uriBuilder);
@@ -661,7 +664,7 @@ public class BaseDhis2 {
     addParameter(uriBuilder, "enrolledBefore", query.getEnrolledBefore());
     addParameter(uriBuilder, "trackedEntityType", query.getTrackedEntityType());
     addParameter(uriBuilder, "trackedEntity", query.getTrackedEntity());
-    addParameterList(uriBuilder, "order", query.getOrder());
+    addOrder(uriBuilder, query);
     addParameterList(uriBuilder, "enrollments", query.getEnrollments());
     addParameter(uriBuilder, "includeDeleted", query.getIncludeDeleted());
 
@@ -1568,6 +1571,33 @@ public class BaseDhis2 {
 
     final Header locationHeader = response.getLastHeader(HttpHeaders.LOCATION);
     return isPresent(locationHeader) && locationHeader.getValue().contains("dhis-web-login");
+  }
+
+  /**
+   * Returns the fields to request for the given {@link MetadataEntity} and {@link Query}. Returns
+   * the fields specified on the query, if any. Otherwise, falls back to the extended or standard
+   * fields of the entity, based on whether the query has association expansion enabled.
+   *
+   * @param entity the {@link MetadataEntity}.
+   * @param query the {@link Query}.
+   * @return the fields to request.
+   */
+  protected String getQueryFields(MetadataEntity entity, Query query) {
+    String entityFields = query.isExpandAssociations() ? entity.getExtFields() : entity.getFields();
+    return getQueryFieldsOrDefault(query, entityFields);
+  }
+
+  /**
+   * Returns the fields specified on the given {@link BaseQuery}, or the given default fields if the
+   * query does not specify any fields.
+   *
+   * @param query the {@link BaseQuery}.
+   * @param defaultFields the default fields to use.
+   * @return the fields to request.
+   */
+  protected String getQueryFieldsOrDefault(BaseQuery query, String defaultFields) {
+    final String queryFields = query.getFields();
+    return StringUtils.isNotBlank(queryFields) ? queryFields : defaultFields;
   }
 
   /**

--- a/src/main/java/org/hisp/dhis/Dhis2.java
+++ b/src/main/java/org/hisp/dhis/Dhis2.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.api.ApiFields.DATA_SET_VALIDATION_FIELDS;
 import static org.hisp.dhis.api.ApiFields.FILE_RESOURCE_FIELDS;
 import static org.hisp.dhis.api.ApiFields.ME_FIELDS;
 import static org.hisp.dhis.api.ApiFields.ORG_UNIT_FIELDS;
+import static org.hisp.dhis.api.ApiFields.PERIOD_TYPE_FIELDS;
 import static org.hisp.dhis.api.ApiFields.TRACKED_ENTITY_FIELDS;
 import static org.hisp.dhis.api.ApiFields.VALIDATION_RULE_FIELDS;
 import static org.hisp.dhis.api.ApiParams.ASYNC_PARAM;
@@ -780,7 +781,7 @@ public class Dhis2 extends BaseDhis2 {
    */
   public Dhis2Objects getMetadataObjects(MetadataEntity entity, Query query) {
     String path = entity.getPath();
-    String fields = query.isExpandAssociations() ? entity.getExtFields() : entity.getFields();
+    String fields = getQueryFields(entity, query);
     URIBuilder uri =
         config.getResolvedUriBuilder().appendPath(path).addParameter(FIELDS_PARAM, fields);
     return getObject(uri, query, Dhis2Objects.class);
@@ -798,7 +799,7 @@ public class Dhis2 extends BaseDhis2 {
   public <T extends IdentifiableObject> List<T> getMetadataList(
       MetadataEntity entity, Query query) {
     String path = entity.getPath();
-    String fields = query.isExpandAssociations() ? entity.getExtFields() : entity.getFields();
+    String fields = getQueryFields(entity, query);
 
     Dhis2Objects objects =
         getObject(
@@ -821,7 +822,7 @@ public class Dhis2 extends BaseDhis2 {
   public <T extends IdentifiableObject> Metadata<T> getMetadata(
       MetadataEntity entity, Query query) {
     String path = entity.getPath();
-    String fields = query.isExpandAssociations() ? entity.getExtFields() : entity.getFields();
+    String fields = getQueryFields(entity, query);
     InternalQuery internalQuery = InternalQuery.instance().withDefaultPaging();
 
     Dhis2Objects objects =
@@ -2351,12 +2352,13 @@ public class Dhis2 extends BaseDhis2 {
    * @return list of {@link OrgUnit}.
    */
   public List<OrgUnit> getOrgUnitSubHierarchy(String id, Integer level, Query query) {
+    final String fields = getQueryFieldsOrDefault(query, ORG_UNIT_FIELDS);
     return getObject(
             config
                 .getResolvedUriBuilder()
                 .appendPath("organisationUnits")
                 .appendPath(id)
-                .addParameter(FIELDS_PARAM, ORG_UNIT_FIELDS)
+                .addParameter(FIELDS_PARAM, fields)
                 .addParameter("level", String.valueOf(level)),
             query,
             Dhis2Objects.class)
@@ -3933,11 +3935,12 @@ public class Dhis2 extends BaseDhis2 {
    * @return list of {@link PeriodType}.
    */
   public List<PeriodType> getPeriodTypes(Query query) {
+    final String fields = getQueryFieldsOrDefault(query, PERIOD_TYPE_FIELDS);
     return getObject(
             config
                 .getResolvedUriBuilder()
                 .appendPath("periodTypes")
-                .addParameter(FIELDS_PARAM, "frequencyOrder,name,isoDuration,isoFormat"),
+                .addParameter(FIELDS_PARAM, fields),
             query,
             Dhis2Objects.class)
         .getPeriodTypes();
@@ -3972,11 +3975,12 @@ public class Dhis2 extends BaseDhis2 {
    * @return a list of {@link FileResource}.
    */
   public List<FileResource> getFileResources(Query query) {
+    String fields = getQueryFieldsOrDefault(query, FILE_RESOURCE_FIELDS);
     return getObject(
             config
                 .getResolvedUriBuilder()
                 .appendPath(PATH_FILE_RESOURCES)
-                .addParameter(FIELDS_PARAM, FILE_RESOURCE_FIELDS),
+                .addParameter(FIELDS_PARAM, fields),
             query,
             Dhis2Objects.class)
         .getFileResources();
@@ -4644,12 +4648,13 @@ public class Dhis2 extends BaseDhis2 {
    * @return the {@link TrackedEntitiesResult}.
    */
   public TrackedEntitiesResult getTrackedEntities(TrackedEntityQuery query) {
+    final String fields = getQueryFieldsOrDefault(query, TRACKED_ENTITY_FIELDS);
     return getTrackedEntitiesResult(
         config
             .getResolvedUriBuilder()
             .appendPath(PATH_TRACKER)
             .appendPath(PATH_TRACKED_ENTITIES)
-            .addParameter(FIELDS_PARAM, TRACKED_ENTITY_FIELDS),
+            .addParameter(FIELDS_PARAM, fields),
         query);
   }
 

--- a/src/main/java/org/hisp/dhis/api/ApiFields.java
+++ b/src/main/java/org/hisp/dhis/api/ApiFields.java
@@ -536,4 +536,7 @@ public class ApiFields {
           periods[%2$s],userOrganisationUnit,\
           userOrganisationUnitChildren,userOrganisationUnitGrandChildren,organisationUnits[%2$s]""",
           NAME_EXT_FIELDS, ID_FIELDS);
+
+  /** Period type fields. */
+  public static final String PERIOD_TYPE_FIELDS = "frequencyOrder,name,isoDuration,isoFormat";
 }

--- a/src/main/java/org/hisp/dhis/model/enrollment/EnrollmentsResult.java
+++ b/src/main/java/org/hisp/dhis/model/enrollment/EnrollmentsResult.java
@@ -29,21 +29,21 @@ package org.hisp.dhis.model.enrollment;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import org.hisp.dhis.model.Pager;
 
 @Getter
-@Setter
-@NoArgsConstructor
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class EnrollmentsResult implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  @JsonProperty private List<Enrollment> enrollments = new ArrayList<>();
+  /** Paging information. */
+  @JsonProperty private final Pager pager;
 
-  public EnrollmentsResult(List<Enrollment> enrollments) {
-    this.enrollments = enrollments;
-  }
+  @JsonProperty private final List<Enrollment> enrollments;
 }

--- a/src/main/java/org/hisp/dhis/model/event/EventsResult.java
+++ b/src/main/java/org/hisp/dhis/model/event/EventsResult.java
@@ -31,15 +31,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import org.hisp.dhis.model.Pager;
 
 @Getter
-@Setter
-@NoArgsConstructor
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class EventsResult implements Serializable {
   private static final long serialVersionUID = 1L;
 
+  /** Paging information. */
+  @JsonProperty private final Pager pager;
+
+  /** List of events. */
   @JsonProperty private final List<Event> events = new ArrayList<>();
 }

--- a/src/main/java/org/hisp/dhis/model/relationship/RelationshipsResult.java
+++ b/src/main/java/org/hisp/dhis/model/relationship/RelationshipsResult.java
@@ -29,21 +29,21 @@ package org.hisp.dhis.model.relationship;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import org.hisp.dhis.model.Pager;
 
 @Getter
-@Setter
-@NoArgsConstructor
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class RelationshipsResult implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  @JsonProperty private List<Relationship> relationships = new ArrayList<>();
+  /** Paging information. */
+  @JsonProperty private final Pager pager;
 
-  public RelationshipsResult(List<Relationship> relationships) {
-    this.relationships = relationships;
-  }
+  @JsonProperty private final List<Relationship> relationships;
 }

--- a/src/main/java/org/hisp/dhis/model/trackedentity/ProgramOwner.java
+++ b/src/main/java/org/hisp/dhis/model/trackedentity/ProgramOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,16 +25,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.query;
+package org.hisp.dhis.model.trackedentity;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
-public interface BaseQuery {
-  List<Filter> getFilters();
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class ProgramOwner implements Serializable {
+  @JsonProperty private String orgUnit;
 
-  List<Order> getOrder();
+  @JsonProperty private String trackedEntity;
 
-  Paging getPaging();
-
-  String getFields();
+  @JsonProperty private String program;
 }

--- a/src/main/java/org/hisp/dhis/model/trackedentity/TrackedEntitiesResult.java
+++ b/src/main/java/org/hisp/dhis/model/trackedentity/TrackedEntitiesResult.java
@@ -29,19 +29,24 @@ package org.hisp.dhis.model.trackedentity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
+import org.hisp.dhis.model.Pager;
 
 @Getter
-@Setter
 @ToString
-@NoArgsConstructor
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class TrackedEntitiesResult implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  @JsonProperty private final List<TrackedEntity> trackedEntities = new ArrayList<>();
+  /** Paging information. */
+  @JsonProperty private final Pager pager;
+
+  /** List of tracked entities. */
+  @JsonProperty private final List<TrackedEntity> trackedEntities;
 }

--- a/src/main/java/org/hisp/dhis/model/trackedentity/TrackedEntity.java
+++ b/src/main/java/org/hisp/dhis/model/trackedentity/TrackedEntity.java
@@ -93,6 +93,8 @@ public class TrackedEntity implements Serializable {
 
   @JsonProperty private List<Enrollment> enrollments = new ArrayList<>();
 
+  @JsonProperty private List<ProgramOwner> programOwners = new ArrayList<>();
+
   public TrackedEntity(String id) {
     this.trackedEntity = id;
   }

--- a/src/main/java/org/hisp/dhis/query/Paging.java
+++ b/src/main/java/org/hisp/dhis/query/Paging.java
@@ -45,14 +45,19 @@ public class Paging {
 
   private static final int DEFAULT_PAGE = 1;
 
+  private static final boolean DEFAULT_TOTAL_PAGES = false;
+
   private final Integer page;
 
   private final Integer pageSize;
+
+  private final boolean totalPages;
 
   /** Constructor. */
   public Paging() {
     this.page = DEFAULT_PAGE;
     this.pageSize = DEFAULT_PAGE_SIZE;
+    this.totalPages = DEFAULT_TOTAL_PAGES;
   }
 
   /**
@@ -62,11 +67,22 @@ public class Paging {
    * @param pageSize the page size, can be null, cannot be negative.
    */
   public Paging(Integer page, Integer pageSize) {
+    this(page, pageSize, DEFAULT_TOTAL_PAGES);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param page the page number, starting on 1, can be null, cannot be negative.
+   * @param pageSize the page size, can be null, cannot be negative.
+   */
+  public Paging(Integer page, Integer pageSize, boolean totalPages) {
     Validate.isTrue(!(isPresent(page) && page < 1), "Page must be greater than zero if specified");
     Validate.isTrue(
         !(isPresent(pageSize) && pageSize < 1), "Page size must be greater than zero if specified");
     this.page = page;
     this.pageSize = pageSize;
+    this.totalPages = totalPages;
   }
 
   /**

--- a/src/main/java/org/hisp/dhis/query/Query.java
+++ b/src/main/java/org/hisp/dhis/query/Query.java
@@ -53,6 +53,8 @@ public class Query implements BaseQuery {
 
   private boolean expandAssociations = false;
 
+  private String fields;
+
   /**
    * Produces a query instance.
    *
@@ -158,6 +160,27 @@ public class Query implements BaseQuery {
   @Override
   public Paging getPaging() {
     return isPresent(paging) ? paging : new Paging(null, null);
+  }
+
+  /**
+   * Sets fields for this query.
+   *
+   * @param fields the query fields.
+   * @return this {@link Query}.
+   */
+  public Query setFields(String fields) {
+    this.fields = fields;
+    return this;
+  }
+
+  /**
+   * Returns the fields for this query.
+   *
+   * @return the fields.
+   */
+  @Override
+  public String getFields() {
+    return this.fields;
   }
 
   /**

--- a/src/main/java/org/hisp/dhis/query/enrollment/EnrollmentQuery.java
+++ b/src/main/java/org/hisp/dhis/query/enrollment/EnrollmentQuery.java
@@ -37,15 +37,26 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.hisp.dhis.model.enrollment.EnrollmentStatus;
+import org.hisp.dhis.query.BaseQuery;
+import org.hisp.dhis.query.Filter;
+import org.hisp.dhis.query.Order;
+import org.hisp.dhis.query.Paging;
 import org.hisp.dhis.query.event.OrgUnitSelectionMode;
 
 @Getter
 @Setter
 @Accessors(chain = true)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class EnrollmentQuery {
+public class EnrollmentQuery implements BaseQuery {
+  private Paging paging = new Paging();
+
+  private List<Filter> filters = new ArrayList<>();
+
   /** Only return enrollments belonging to provided organisation units */
   private List<String> orgUnits = new ArrayList<>();
+
+  /** Any valid field filter. Include specified sub-objects in the response. */
+  private String fields;
 
   /**
    * The mode of selecting organisation units, can be. Default is SELECTED, which refers to the
@@ -85,10 +96,10 @@ public class EnrollmentQuery {
    * Supported fields: completedAt, createdAt, createdAtClient, enrolledAt, updatedAt,
    * updatedAtClient.
    */
-  private List<String> order;
+  private List<Order> order = new ArrayList<>();
 
   /** Filter the result down to a limited set of IDs by using enrollments=id1,id2. */
-  private List<String> enrollments;
+  private List<String> enrollments = new ArrayList<>();
 
   /** When true, soft deleted events will be included in your query result. */
   private Boolean includeDeleted;

--- a/src/main/java/org/hisp/dhis/query/event/EventQuery.java
+++ b/src/main/java/org/hisp/dhis/query/event/EventQuery.java
@@ -54,6 +54,9 @@ public class EventQuery implements BaseQuery {
 
   private Paging paging = new Paging();
 
+  /** Any valid field filter. Include specified sub-objects in the response. */
+  private String fields;
+
   private String program;
 
   private String programStage;

--- a/src/main/java/org/hisp/dhis/query/trackedentity/TrackedEntityQuery.java
+++ b/src/main/java/org/hisp/dhis/query/trackedentity/TrackedEntityQuery.java
@@ -58,6 +58,9 @@ public class TrackedEntityQuery implements BaseQuery {
 
   private List<String> orgUnits = new ArrayList<>();
 
+  /** Any valid field filter. Include specified sub-objects in the response. */
+  private String fields;
+
   private OrgUnitSelectionMode orgUnitMode;
 
   private String program;

--- a/src/main/java/org/hisp/dhis/util/query/FilterUtils.java
+++ b/src/main/java/org/hisp/dhis/util/query/FilterUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.util.query;
+
+import static org.hisp.dhis.query.Operator.fromValue;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hisp.dhis.query.Filter;
+import org.hisp.dhis.query.Operator;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FilterUtils {
+  private static final Pattern FILTER_PATTERN = Pattern.compile("^([a-zA-Z0-9]+):([a-z]+):(.*)$");
+  private static final String INVALID_OPERATOR = "Filter operator is invalid: '%s'";
+  private static final String INVALID_FILTER_FORMAT =
+      "Filter must be on the format '{property}:{operator}:{value}': '%s'";
+
+  /**
+   * Creates a list of {@link Filter} from the given list of strings. The values must be on the
+   * format {@code property:operator:value}. For "in" type filters, multiple values must be
+   * separated by {@code ;}. Returns an empty list if the given list is null.
+   *
+   * @param strings the list of strings.
+   * @return a list of {@link Filter}.
+   */
+  public static List<Filter> asFilters(List<String> strings) {
+    if (strings == null) {
+      return List.of();
+    }
+
+    return strings.stream().map(FilterUtils::asFilter).toList();
+  }
+
+  /**
+   * Creates a {@link Filter} from the given string. The value must be on the format {@code
+   * property:operator:value}. For "in" type filters, multiple values must be separated by {@code
+   * ;}. Returns null if the given string is null.
+   *
+   * @param string the filter string.
+   * @return a {@link Filter}.
+   * @throws IllegalArgumentException if the string format is invalid.
+   */
+  public static Filter asFilter(String string) {
+    if (string == null) {
+      return null;
+    }
+
+    Matcher matcher = FILTER_PATTERN.matcher(string);
+
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(String.format(INVALID_FILTER_FORMAT, string));
+    }
+
+    String property = matcher.group(1);
+    Operator operator = fromValue(matcher.group(2));
+    Object value = matcher.group(3);
+
+    if (operator == null) {
+      throw new IllegalArgumentException(String.format(INVALID_OPERATOR, matcher.group(2)));
+    }
+
+    return new Filter(property, operator, value);
+  }
+
+  /**
+   * Creates a {@link String} from the given {@link Filter}. The result value will have the format
+   * {@code property:operator:value}. For "in" type filters, multiple values must be separated by
+   * {@code ,}. Returns null if the given {@link Filter} is null.
+   *
+   * @param filter the {@link Filter}.
+   * @return a string in the format {@code property:operator:value}.
+   */
+  public static String asString(Filter filter) {
+    if (filter == null) {
+      return null;
+    }
+
+    return filter.getProperty() + ":" + filter.getOperator().value() + ":" + filter.getValue();
+  }
+}

--- a/src/main/java/org/hisp/dhis/util/query/OrderingUtils.java
+++ b/src/main/java/org/hisp/dhis/util/query/OrderingUtils.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.util.query;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hisp.dhis.query.Direction;
+import org.hisp.dhis.query.Order;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderingUtils {
+  private static final Pattern ORDER_PATTERN = Pattern.compile("^([a-zA-Z0-9]+):([a-z]+)$");
+  private static final String INVALID_ORDER_DIRECTION = "Direction is invalid: '%s'";
+  private static final String INVALID_ORDER_FORMAT =
+      "Order must be on the format '{property}:{direction}': '%s'";
+
+  /**
+   * Creates a list of {@link Order} from the given list of order. The values must be on the format
+   * {@code property:direction}. Returns empty List if the given order list is null.
+   *
+   * @param order the list of order.
+   * @return a list of {@link Order}.
+   */
+  public static List<Order> asOrders(List<String> order) {
+    if (order == null) {
+      return List.of();
+    }
+
+    return order.stream().map(OrderingUtils::asOrder).toList();
+  }
+
+  /**
+   * Creates a {@link Order} from the given string. The value must be on the format {@code
+   * property:direction}. Returns null if the given order string is null.
+   *
+   * @param string the filter string.
+   * @return a {@link Order}.
+   * @throws IllegalArgumentException if the string format is invalid.
+   */
+  public static Order asOrder(String string) {
+    if (string == null) {
+      return null;
+    }
+
+    Matcher matcher = ORDER_PATTERN.matcher(string);
+
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(String.format(INVALID_ORDER_FORMAT, string));
+    }
+
+    String property = matcher.group(1);
+    Direction direction = Direction.fromValue(matcher.group(2));
+
+    if (direction == null) {
+      throw new IllegalArgumentException(String.format(INVALID_ORDER_DIRECTION, matcher.group(2)));
+    }
+
+    return Direction.DESC == direction ? Order.desc(property) : Order.asc(property);
+  }
+
+  /**
+   * Creates a {@link String} from the given {@link Order}. The result value will have the format
+   * {@code property:direction}. Returns null if the given {@link Order} is null.
+   *
+   * @param order the {@link Order}.
+   * @return a string in the format {@code property:direction}.
+   */
+  public static String asString(Order order) {
+    if (order == null) {
+      return null;
+    }
+
+    return order.getProperty() + ":" + order.getDirection().value();
+  }
+}

--- a/src/test/java/org/hisp/dhis/BaseDhis2Test.java
+++ b/src/test/java/org/hisp/dhis/BaseDhis2Test.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis;
 
+import static org.hisp.dhis.api.ApiFields.DATA_ELEMENT_GROUP_EXT_FIELDS;
+import static org.hisp.dhis.api.ApiFields.DATA_ELEMENT_GROUP_FIELDS;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -44,7 +46,14 @@ import org.hisp.dhis.model.AggregationType;
 import org.hisp.dhis.model.DataDomain;
 import org.hisp.dhis.model.DataElement;
 import org.hisp.dhis.model.ValueType;
+import org.hisp.dhis.model.metadata.MetadataEntity;
+import org.hisp.dhis.query.InternalQuery;
+import org.hisp.dhis.query.Order;
+import org.hisp.dhis.query.Paging;
+import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.analytics.AnalyticsQuery;
+import org.hisp.dhis.query.enrollment.EnrollmentQuery;
+import org.hisp.dhis.query.event.EventQuery;
 import org.hisp.dhis.response.Dhis2ClientException;
 import org.hisp.dhis.support.TestTags;
 import org.hisp.dhis.util.CodecUtils;
@@ -157,6 +166,111 @@ class BaseDhis2Test {
             TestFixture.DEFAULT_URL);
 
     assertEquals(expected, decodedUrl);
+  }
+
+  @Test
+  void testGetQueryFieldsReturnsQueryFieldsWhenSet() {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+
+    Query query = Query.instance().setFields("id,name").withExpandAssociations();
+
+    assertEquals("id,name", dhis2.getQueryFields(MetadataEntity.DATA_ELEMENT_GROUP, query));
+  }
+
+  @Test
+  void testGetQueryFieldsReturnsStandardFieldsByDefault() {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+
+    Query query = Query.instance();
+
+    assertEquals(
+        DATA_ELEMENT_GROUP_FIELDS, dhis2.getQueryFields(MetadataEntity.DATA_ELEMENT_GROUP, query));
+  }
+
+  @Test
+  void testGetQueryFieldsReturnsExtFieldsWhenExpandAssociations() {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+
+    Query query = Query.instance().withExpandAssociations();
+
+    assertEquals(
+        DATA_ELEMENT_GROUP_EXT_FIELDS,
+        dhis2.getQueryFields(MetadataEntity.DATA_ELEMENT_GROUP, query));
+  }
+
+  @Test
+  void testGetQueryFieldsOrDefaultReturnsQueryFieldsWhenSet() {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+
+    EventQuery query = EventQuery.instance().setFields("event,status");
+
+    assertEquals("event,status", dhis2.getQueryFieldsOrDefault(query, "default,fields"));
+  }
+
+  @Test
+  void testGetQueryFieldsOrDefaultReturnsDefaultWhenBlank() {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+
+    assertEquals(
+        "default,fields", dhis2.getQueryFieldsOrDefault(EventQuery.instance(), "default,fields"));
+    assertEquals(
+        "default,fields",
+        dhis2.getQueryFieldsOrDefault(EventQuery.instance().setFields("   "), "default,fields"));
+  }
+
+  @Test
+  void testAddPagingAddsTotalPagesParameter() throws Exception {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+
+    EnrollmentQuery query = EnrollmentQuery.instance().setPaging(new Paging(1, 10, true));
+
+    URIBuilder builder = new URIBuilder("https://myserver.org/api");
+
+    dhis2.addPaging(builder, query, InternalQuery.instance());
+
+    assertEquals("https://myserver.org/api?page=1&pageSize=10&totalPages=true", builder.toString());
+  }
+
+  @Test
+  void testAddPagingWithNullPagingAndDefaultPagingAddsNoParameters() throws Exception {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+
+    EnrollmentQuery query = EnrollmentQuery.instance().setPaging(null);
+
+    URIBuilder builder = new URIBuilder("https://myserver.org/api");
+
+    dhis2.addPaging(builder, query, InternalQuery.instance().withDefaultPaging());
+
+    assertEquals("https://myserver.org/api", builder.toString());
+  }
+
+  @Test
+  void testAddPagingWithNullPagingAndNoDefaultPagingDisablesPaging() throws Exception {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+
+    EnrollmentQuery query = EnrollmentQuery.instance().setPaging(null);
+
+    URIBuilder builder = new URIBuilder("https://myserver.org/api");
+
+    dhis2.addPaging(builder, query, InternalQuery.instance());
+
+    assertEquals("https://myserver.org/api?paging=false", builder.toString());
+  }
+
+  @Test
+  void testWithEnrollmentQueryParamsAddsOrder() throws Exception {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+
+    EnrollmentQuery query =
+        EnrollmentQuery.instance().setOrder(List.of(Order.asc("enrolledAt"), Order.desc("status")));
+
+    URIBuilder uriBuilder = new URIBuilder("https://myserver.org/api/tracker/enrollments");
+
+    URI uri = dhis2.withEnrollmentQueryParams(uriBuilder, query);
+
+    assertEquals(
+        "https://myserver.org/api/tracker/enrollments?order=enrolledAt:asc,status:desc",
+        CodecUtils.decode(uri));
   }
 
   @Test

--- a/src/test/java/org/hisp/dhis/EnrollmentsApiTest.java
+++ b/src/test/java/org/hisp/dhis/EnrollmentsApiTest.java
@@ -98,7 +98,7 @@ class EnrollmentsApiTest {
     enrollment.setOccurredAt(toDate(2021, 7, 12));
     Note note = new Note();
     note.setNote(noteId);
-    note.setStoredBy("admin");
+    note.setStoredBy("system");
     note.setValue(StringUtils.repeat('a', 5000));
     enrollment.setNotes(List.of(note));
 
@@ -131,7 +131,7 @@ class EnrollmentsApiTest {
     note = enrollment.getNotes().get(0);
     assertEquals(noteId, note.getNote());
     assertEquals(5000, note.getValue().length());
-    assertEquals("admin", note.getStoredBy());
+    assertEquals("system", note.getStoredBy());
 
     trackedEntityObjects = new TrackedEntityObjects();
     trackedEntityObjects.addEnrollment(enrollment);

--- a/src/test/java/org/hisp/dhis/ProgramRuleVariableApiTest.java
+++ b/src/test/java/org/hisp/dhis/ProgramRuleVariableApiTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import org.hisp.dhis.model.DataElement;
 import org.hisp.dhis.model.Program;
 import org.hisp.dhis.model.ValueType;
 import org.hisp.dhis.model.programrule.ProgramRuleVariable;
@@ -108,6 +109,9 @@ class ProgramRuleVariableApiTest {
     Program program = new Program();
     program.setId("IpHINAT79UW"); // Child Programme
 
+    DataElement dataElement = new DataElement();
+    dataElement.setId("H6uSAMO5WLD"); // MCH Apgar comment
+
     ProgramRuleVariable programRuleVariable = new ProgramRuleVariable();
     programRuleVariable.setId(uidA);
     programRuleVariable.setName(uidA);
@@ -115,6 +119,7 @@ class ProgramRuleVariableApiTest {
     programRuleVariable.setProgramRuleVariableSourceType(DATAELEMENT_NEWEST_EVENT_PROGRAM);
     programRuleVariable.setValueType(ValueType.TEXT);
     programRuleVariable.setProgram(program);
+    programRuleVariable.setDataElement(dataElement);
 
     // Create
     ObjectResponse createResp = dhis2.saveMetadataObject(programRuleVariable);

--- a/src/test/java/org/hisp/dhis/TestFixture.java
+++ b/src/test/java/org/hisp/dhis/TestFixture.java
@@ -38,9 +38,9 @@ import lombok.NoArgsConstructor;
 public final class TestFixture {
   public static final String DEV_URL = "https://play.im.dhis2.org/dev";
 
-  public static final String V41_URL = "https://play.im.dhis2.org/stable-2-41-9";
+  public static final String V41_URL = "https://play.im.dhis2.org/stable-2-41-9-1";
 
-  public static final String V42_URL = "https://play.im.dhis2.org/stable-2-42-5-1";
+  public static final String V42_URL = "https://play.im.dhis2.org/stable-2-42-5-2";
 
   public static final String LOCAL_URL = "http://localhost/dhis";
 

--- a/src/test/java/org/hisp/dhis/TrackedEntityApiTest.java
+++ b/src/test/java/org/hisp/dhis/TrackedEntityApiTest.java
@@ -32,8 +32,10 @@ import static org.hisp.dhis.support.Assertions.assertSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
+import org.hisp.dhis.model.Pager;
 import org.hisp.dhis.model.enrollment.Enrollment;
 import org.hisp.dhis.model.enrollment.EnrollmentStatus;
 import org.hisp.dhis.model.trackedentity.TrackedEntitiesResult;
@@ -124,6 +126,38 @@ class TrackedEntityApiTest {
     assertNotNull(trackedEntities);
     assertNotEmpty(trackedEntities.getTrackedEntities());
     assertSize(2, trackedEntities.getTrackedEntities());
+
+    assertNotNull(trackedEntities.getPager());
+    Pager pager = trackedEntities.getPager();
+    assertNull(pager.getPageCount());
+    assertNull(pager.getTotal());
+    assertEquals(1, pager.getPage());
+    assertEquals(2, pager.getPageSize());
+  }
+
+  @Test
+  void testGetTrackedEntitiesWithTotalPaging() {
+    Dhis2 dhis2 = new Dhis2(TestFixture.DEFAULT_CONFIG);
+
+    TrackedEntityQuery query =
+        TrackedEntityQuery.instance()
+            .setProgram("IpHINAT79UW")
+            .setOrgUnit("DiszpKrYNg8")
+            .setFields("trackedEntity,programOwners")
+            .setPaging(new Paging(1, 2, true));
+
+    TrackedEntitiesResult trackedEntities = dhis2.getTrackedEntities(query);
+
+    assertNotNull(trackedEntities);
+    assertNotEmpty(trackedEntities.getTrackedEntities());
+    assertSize(2, trackedEntities.getTrackedEntities());
+
+    assertNotNull(trackedEntities.getPager());
+    Pager pager = trackedEntities.getPager();
+    assertNotNull(pager.getPageCount());
+    assertNotNull(pager.getTotal());
+    assertEquals(1, pager.getPage());
+    assertEquals(2, pager.getPageSize());
   }
 
   @Test

--- a/src/test/java/org/hisp/dhis/model/trackedentity/TrackedEntityTest.java
+++ b/src/test/java/org/hisp/dhis/model/trackedentity/TrackedEntityTest.java
@@ -62,7 +62,8 @@ class TrackedEntityTest {
         "updatedAt":"2023-05-10T16:12:51.251",\
         "orgUnit":"DiszpKrYNg8",\
         "attributes":[],\
-        "enrollments":[]}""";
+        "enrollments":[],\
+        "programOwners":[]}""";
 
     assertEquals(expected, actual);
   }

--- a/src/test/java/org/hisp/dhis/util/query/FilterUtilsTest.java
+++ b/src/test/java/org/hisp/dhis/util/query/FilterUtilsTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.util.query;
+
+import static org.hisp.dhis.query.Operator.EQ;
+import static org.hisp.dhis.query.Operator.GT;
+import static org.hisp.dhis.query.Operator.ILIKE;
+import static org.hisp.dhis.query.Operator.LT;
+import static org.hisp.dhis.query.Operator.TOKEN;
+import static org.hisp.dhis.util.query.FilterUtils.asFilter;
+import static org.hisp.dhis.util.query.FilterUtils.asString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.hisp.dhis.query.Filter;
+import org.hisp.dhis.support.TestTags;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(TestTags.UNIT)
+class FilterUtilsTest {
+  @Test
+  void testAsFilter() {
+    Filter filter = asFilter("name:eq:DHIS2");
+    assertEquals("name", filter.getProperty());
+    assertEquals(EQ, filter.getOperator());
+    assertEquals("DHIS2", filter.getValue());
+
+    filter = asFilter("weight:gt:2");
+    assertEquals("weight", filter.getProperty());
+    assertEquals(GT, filter.getOperator());
+    assertEquals("2", filter.getValue());
+
+    filter = asFilter("retryAttempts:lt:3");
+    assertEquals("retryAttempts", filter.getProperty());
+    assertEquals(LT, filter.getOperator());
+    assertEquals("3", filter.getValue());
+
+    filter = asFilter("name:ilike:mae.ngo.org: Exit interview");
+    assertEquals("name", filter.getProperty());
+    assertEquals(ILIKE, filter.getOperator());
+    assertEquals("mae.ngo.org: Exit interview", filter.getValue());
+  }
+
+  @Test
+  void testAsString() {
+    Filter filter = new Filter("name", EQ, "DHIS2");
+    assertEquals("name:eq:DHIS2", asString(filter));
+
+    filter = new Filter("weight", GT, 2);
+    assertEquals("weight:gt:2", asString(filter));
+
+    filter = new Filter("retryAttempts", LT, 3);
+    assertEquals("retryAttempts:lt:3", asString(filter));
+
+    filter = new Filter("name", ILIKE, "mae.ngo.org: Exit interview");
+    assertEquals("name:ilike:mae.ngo.org: Exit interview", asString(filter));
+
+    filter = new Filter("name", TOKEN, "Exit interview");
+    assertEquals("name:token:Exit interview", asString(filter));
+  }
+
+  @Test
+  void testInvalidFilterFormat() {
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> asFilter("disabled:true"));
+    assertEquals(
+        "Filter must be on the format '{property}:{operator}:{value}': 'disabled:true'",
+        ex.getMessage());
+  }
+
+  @Test
+  void testInvalidFilterOperator() {
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> asFilter("name:notanoperator:MySQL"));
+    assertEquals("Filter operator is invalid: 'notanoperator'", ex.getMessage());
+  }
+}

--- a/src/test/java/org/hisp/dhis/util/query/OrderingUtilsTest.java
+++ b/src/test/java/org/hisp/dhis/util/query/OrderingUtilsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.util.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.hisp.dhis.query.Order;
+import org.hisp.dhis.support.TestTags;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(TestTags.UNIT)
+class OrderingUtilsTest {
+  @Test
+  void testAsOrder() {
+    assertNull(OrderingUtils.asOrder(null));
+
+    orderEquals(Order.asc("name"), OrderingUtils.asOrder("name:asc"));
+    orderEquals(Order.desc("name"), OrderingUtils.asOrder("name:desc"));
+    orderEquals(Order.asc("description"), OrderingUtils.asOrder("description:asc"));
+    orderEquals(Order.desc("termsOfUse"), OrderingUtils.asOrder("termsOfUse:desc"));
+  }
+
+  @Test
+  void testAsString() {
+    assertNull(OrderingUtils.asString(null));
+
+    assertEquals("name:asc", OrderingUtils.asString(Order.asc("name")));
+    assertEquals("name:desc", OrderingUtils.asString(Order.desc("name")));
+    assertEquals("description:asc", OrderingUtils.asString(Order.asc("description")));
+    assertEquals("termsOfUse:desc", OrderingUtils.asString(Order.desc("termsOfUse")));
+  }
+
+  @Test
+  void testInvalidOrderFormat() {
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> OrderingUtils.asOrder("name"));
+    assertEquals("Order must be on the format '{property}:{direction}': 'name'", ex.getMessage());
+  }
+
+  @Test
+  void testInvalidOrderDirection() {
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> OrderingUtils.asOrder("name:sideways"));
+    assertEquals("Direction is invalid: 'sideways'", ex.getMessage());
+  }
+
+  private void orderEquals(Order expected, Order actual) {
+    assertEquals(expected.getDirection(), actual.getDirection());
+    assertEquals(expected.getProperty(), actual.getProperty());
+  }
+}


### PR DESCRIPTION
  - Add support for a custom fields parameter on Query, EnrollmentQuery, EventQuery, and TrackedEntityQuery, so callers can override the default/extended field set per request instead of only choosing between the two presets.                                                                                                                             
  - Add a totalPages option to Paging (and wire it through BaseDhis2.addPaging) so callers can request the totalPages=true DHIS2 paging parameter. addPaging is also now null-safe for Paging.                                                                                                                                                         
  - Expose paging metadata on collection results: EnrollmentsResult, EventsResult, RelationshipsResult, and TrackedEntitiesResult now carry a Pager.                            
  - Add TrackedEntity.programOwners (backed by a new ProgramOwner model).                                                                                                       
  - Fix enrollment ordering to build order from typed Order objects instead of raw strings, matching how event/tracked entity queries already work.                             
  - Add FilterUtils and OrderingUtils for parsing/formatting property:operator:value filter strings and property:direction order strings.                                       
  - Bump version to 2.7.8.  